### PR TITLE
Fix iFunny website links not working

### DIFF
--- a/src/messageHandling/handlers/iFunny.ts
+++ b/src/messageHandling/handlers/iFunny.ts
@@ -2,7 +2,7 @@ import {Client, DiscordAPIError, Message, MessageAttachment} from "discord.js";
 import cheerio from 'cheerio';
 import got from 'got';
 
-const iFunnyVideoRegEx = new RegExp('https:\\/\\/ifunny.co\\/(video|picture|gif)\\/\\w+', 'g');
+const iFunnyVideoRegEx = new RegExp('https:\\/\\/ifunny.co\\/(video|picture|gif)\\/[\\w-]+', 'g');
 
 export const handleIFunnyVideo = (client: Client, message: Message): boolean => {
     const matches = [...message.content.matchAll(iFunnyVideoRegEx)];


### PR DESCRIPTION
Sometimes the links from the web page version of iFunny have dashes in them. Updated the RegEx to handle that.